### PR TITLE
Add workflow-dispatch trigger for OpenSSF workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -14,6 +14,8 @@ on:
     - cron: '28 2 * * 4'
   push:
     branches: [ "master" ]
+  workflow_dispatch:
+
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
This PR adds `workflow-dispatch` trigger to the OpenSSF workflow which would allow one to manually trigger it to run.