### PR TITLE
Set default WF permissions to read-all

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -2,6 +2,8 @@ name: Conda package
 
 on: push
 
+permissions: read-all
+
 env:
   PACKAGE_NAME: mkl_umath
   MODULE_NAME: mkl_umath


### PR DESCRIPTION
The workflow needs to set default permissions to read-all per Open SSF guidelines.