### PR TITLE
Fix build in CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -52,7 +52,7 @@ jobs:
             $TEST \
             $VERSIONS \
             $CHANNELS \
-            conda-recipe-cf
+            conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.4.3
@@ -174,7 +174,7 @@ jobs:
       - name: Build conda package
         run: |
           conda activate
-          conda build --no-test --python ${{ matrix.python }} -c conda-forge -c https://software.repos.intel.com/python/conda --override-channels conda-recipe-cf
+          conda build --no-test --python ${{ matrix.python }} -c conda-forge -c https://software.repos.intel.com/python/conda --override-channels conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.4.3

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -145,6 +145,7 @@ jobs:
           miniforge-version: latest
           activate-environment: build
           channels: conda-forge
+          conda-remove-defaults: true
           python-version: ${{ matrix.python }}
 
       - name: Cache conda packages
@@ -208,7 +209,8 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: mkl_umath_test
-          channels: conda-forge,nodefaults
+          channels: conda-forge
+          conda-remove-defaults: true
           python-version: ${{ matrix.python }}
 
       - name: Install conda-index


### PR DESCRIPTION
This PR fixes the CI builds by using numpy-base as the dependency in meta.yaml for conda-recipe-cf, as building with numpy from conda-forge is currently broken, resulting in `mkl_umath cannot depend on itself`

Also removes the default channel, aligning with mkl_fft