### PR TITLE
Fix test_windows in CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -7,6 +7,8 @@ permissions: read-all
 env:
   PACKAGE_NAME: mkl_umath
   MODULE_NAME: mkl_umath
+  VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); d = j['mkl_umath'][0];"
+  VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
 
 jobs:
   build_linux:
@@ -252,6 +254,7 @@ jobs:
       - name: Collect dependencies
         shell: cmd /C CALL {0}
         run: |
+          @ECHO ON
           IF NOT EXIST ver.json (
               copy /Y ${{ env.workdir }}\ver.json .
           )

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -280,6 +280,8 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
+        # add intel-openmp as an explicit dependency
+        # to avoid it being missed when package version is specified exactly
       - name: Install mkl_umath
         shell: cmd /C CALL {0}
         run: |
@@ -292,7 +294,9 @@ jobs:
              SET PACKAGE_VERSION=%%F
           )
           SET "TEST_DEPENDENCIES=pytest pytest-cov"
-          conda install -n mkl_umath_test ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          SET "WORKAROUND_DEPENDENCIES=intel-openmp"
+          SET "DEPENDENCIES=%TEST_DEPENDENCIES% %WORKAROUND_DEPENDENCIES%"
+          conda install -n mkl_umath_test ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment
         shell: cmd /C CALL {0}


### PR DESCRIPTION
This PR fixes the test_windows step in conda-package.yml by manually installing `intel-openmp` into the environment, which is missed as a dependency inexplicably when the `mkl_umath` package and build versions are specified, or it is installed from a local channel in general.

Also slips in a change properly defining the `VER_SCRIPT1` and `VER_SCRIPT2` environment variables in the conda-package workflow