### PR TITLE
Support mkl_umath in virtual environment out of the box

### DIFF
--- a/mkl_umath/__init__.py
+++ b/mkl_umath/__init__.py
@@ -34,3 +34,5 @@ from ._version import __version__
 from ._ufuncs import *
 
 from ._patch import mkl_umath, use_in_numpy, restore, is_patched
+
+del _init_helper

--- a/mkl_umath/__init__.py
+++ b/mkl_umath/__init__.py
@@ -27,6 +27,8 @@
 Implementation of Numpy universal math functions using Intel(R) MKL and Intel(R) C compiler runtime.
 '''
 
+from . import _init_helper
+
 from ._version import __version__
 
 from ._ufuncs import *

--- a/mkl_umath/_init_helper.py
+++ b/mkl_umath/_init_helper.py
@@ -1,0 +1,30 @@
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+import sys
+
+is_venv_win32 = (
+    sys.platform == "win32"
+    and sys.base_exec_prefix != sys.exec_prefix
+    and os.path.isfile(os.path.join(sys.exec_prefix, "pyvenv.cfg"))
+)
+
+if is_venv_win32:
+    dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
+    if os.path.isdir(dll_dir):
+        os.add_dll_directory(dll_dir)
+
+del is_venv_win32

--- a/mkl_umath/_init_helper.py
+++ b/mkl_umath/_init_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Intel Corporation
+# Copyright 2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ is_venv_win32 = (
 )
 
 if is_venv_win32:
+    # In Windows venv: add Library/bin to PATH for proper DLL loading
     dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
     if os.path.isdir(dll_dir):
         os.add_dll_directory(dll_dir)


### PR DESCRIPTION
Since location of "Library\bin" in the virtual environment is not on the default search path, importing of mkl_umath and numpy fails.

This change introduces "_init_helper.py" file which implements the following logic using built-in os Python module:
1. If os.add_dll_directory attribute exists, and VIRTUAL_ENV environment variable is set, and os.path.join(os.environ["VIRTUAL_ENV"], "Library", "bin") folder exists, call os.add_dll_directory with that directory