### PR TITLE
Revert pinning of `mkl` and `mkl-devel` in `conda-recipe-cf`

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -27,11 +27,11 @@ requirements:
       - cython
       - scikit-build
       - python
-      - mkl-devel >=2024.2,<2025.0
+      - mkl-devel
       - numpy
     run:
       - python
-      - mkl >=2024.2,<2025.0
+      - mkl
       - mkl-service
       - {{ pin_compatible('intel-cmplr-lib-rt') }}
 


### PR DESCRIPTION
change to dependency pinning in meta.yaml for conda-recipe-cf was experimental, missed when updating version