### PR TITLE
Extend INSTALL_RPATH to include parent directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ target_link_options(_ufuncs PRIVATE ${_linker_options})
 target_link_libraries(_ufuncs PRIVATE mkl_umath_loops)
 set_target_properties(_ufuncs PROPERTIES C_STANDARD 99)
 if (UNIX)
-  set_target_properties(_ufuncs PROPERTIES INSTALL_RPATH "$ORIGIN")
+  set_target_properties(_ufuncs PROPERTIES INSTALL_RPATH "$ORIGIN/../..;$ORIGIN/../../..;$ORIGIN")
 endif()
 install(TARGETS _ufuncs LIBRARY DESTINATION mkl_umath)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,6 @@ target_compile_definitions(_patch PUBLIC NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSI
 target_link_libraries(_patch PRIVATE mkl_umath_loops)
 set_target_properties(_patch PROPERTIES C_STANDARD 99)
 if (UNIX)
-  set_target_properties(_patch PROPERTIES INSTALL_RPATH "$ORIGIN")
+  set_target_properties(_patch PROPERTIES INSTALL_RPATH "$ORIGIN/../..;$ORIGIN/../../..;$ORIGIN")
 endif()
 install(TARGETS _patch LIBRARY DESTINATION mkl_umath)


### PR DESCRIPTION
This PR updates the INSTALL_RPATH for the _ufuncs target on Unix systems to improve runtime discovery of dependent shared libraries such as libintlc.so.5 (https://github.com/IntelPython/mkl_fft/issues/146). 
In recent builds (e.g., mkl_umath 0.1.4), users encountered runtime errors like:
```
ImportError: libintlc.so.5: cannot open shared object file: No such file or directory
```
Although the library was bundled with the wheel, it could not be located at runtime due to limited RPATH configuration. 
The updated INSTALL_RPATH now includes additional parent directories. This allows the dynamic linker to resolve libraries located in upper-level paths relative to the extension module.