### PR TITLE
Update `conda-package` workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -6,7 +6,6 @@ permissions: read-all
 
 env:
   PACKAGE_NAME: mkl_umath
-  MODULE_NAME: mkl_umath
   VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); d = j['mkl_umath'][0];"
   VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
 
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -68,7 +67,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
+        python: ["3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -122,18 +121,24 @@ jobs:
           # Test installed packages
           conda list -n test_mkl_umath
 
-      - name: Run tests
+      - name: Smoke test
         run: |
           source $CONDA/etc/profile.d/conda.sh
           conda activate test_mkl_umath
           python -c "import mkl_umath, numpy as np; mkl_umath.use_in_numpy(); np.sin(np.linspace(0, 1, num=10**6));"
+
+      - name: Smoke test
+        run: |
+          source $CONDA/etc/profile.d/conda.sh
+          conda activate test_mkl_umath
+          pytest -v --pyargs ${{ env.PACKAGE_NAME }}
 
   build_windows:
     runs-on: windows-2019
 
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
+        python: ["3.9", "3.10", "3.11", "3.12"]
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
@@ -192,7 +197,7 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
+        python: ["3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}
@@ -306,7 +311,12 @@ jobs:
           echo "Value of CONDA_PREFIX enviroment variable was: " %CONDA_PREFIX%
           conda info && conda list -n mkl_umath_test
 
-      - name: Run tests
+      - name: Smoke test
         shell: cmd /C CALL {0}
         run: >-
-          conda activate mkl_umath_test && python -c "import mkl_umath, numpy as np; mkl_umath.use_in_numpy(); np.sin(np.linspace(0, 1, num=10**6));" 
+          conda activate mkl_umath_test && python -c "import mkl_umath, numpy as np; mkl_umath.use_in_numpy(); np.sin(np.linspace(0, 1, num=10**6));"
+
+      - name: Smoke test
+        shell: cmd /C CALL {0}
+        run: |
+          conda activate mkl_umath_test && python -m pytest -v -s --pyargs ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -1,6 +1,10 @@
 name: Conda package
 
-on: push
+on:
+    push:
+      branches:
+        - master
+    pull_request:
 
 permissions: read-all
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -152,7 +152,7 @@ jobs:
           miniforge-version: latest
           activate-environment: build
           channels: conda-forge
-          conda-remove-defaults: true
+          conda-remove-defaults: "true"
           python-version: ${{ matrix.python }}
 
       - name: Cache conda packages
@@ -217,7 +217,7 @@ jobs:
           miniforge-version: latest
           activate-environment: mkl_umath_test
           channels: conda-forge
-          conda-remove-defaults: true
+          conda-remove-defaults: "true"
           python-version: ${{ matrix.python }}
 
       - name: Install conda-index

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -127,7 +127,7 @@ jobs:
           conda activate test_mkl_umath
           python -c "import mkl_umath, numpy as np; mkl_umath.use_in_numpy(); np.sin(np.linspace(0, 1, num=10**6));"
 
-      - name: Smoke test
+      - name: Run tests
         run: |
           source $CONDA/etc/profile.d/conda.sh
           conda activate test_mkl_umath
@@ -316,7 +316,7 @@ jobs:
         run: >-
           conda activate mkl_umath_test && python -c "import mkl_umath, numpy as np; mkl_umath.use_in_numpy(); np.sin(np.linspace(0, 1, num=10**6));"
 
-      - name: Smoke test
+      - name: Run tests
         shell: cmd /C CALL {0}
         run: |
           conda activate mkl_umath_test && python -m pytest -v -s --pyargs ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -20,6 +20,10 @@ jobs:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -146,6 +150,10 @@ jobs:
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 # `mkl_umath`
 
-`mkl_umath._ufuncs` exposes [Intel(R) Math Kernel Library](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html)
+`mkl_umath._ufuncs` exposes [Intel® OneAPI Math Kernel Library (OneMKL)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html)
 powered version of loops used in the patched version of [NumPy](https://numpy.org), that used to be included in
-[Intel(R) Distribution for Python*](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-for-python.html).
+[Intel® Distribution for Python*](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-for-python.html).
 
 Patches were factored out per community feedback ([NEP-36](https://numpy.org/neps/nep-0036-fair-play.html)).
 
-`mkl_umath` started as a part of Intel (R) Distribution for Python* optimizations to NumPy, and is now being released 
-as a stand-alone package. It can be installed into conda environment using 
+`mkl_umath` started as a part of Intel® Distribution for Python* optimizations to NumPy, and is now being released 
+as a stand-alone package. It can be installed into conda environment using:
 
 ```
    conda install -c https://software.repos.intel.com/python/conda mkl_umath
@@ -18,13 +18,13 @@ as a stand-alone package. It can be installed into conda environment using
 
 ---
 
-To install mkl_umath Pypi package please use following command:
+To install mkl_umath PyPI package please use following command:
 
 ```
    python -m pip install --i https://software.repos.intel.com/python/pypi -extra-index-url https://pypi.org/simple mkl_umath
 ```
 
-If command above installs NumPy package from the Pypi, please use following command to install Intel optimized NumPy wheel package from Intel Pypi Cloud:
+If command above installs NumPy package from the PyPI, please use the following command to install Intel optimized NumPy wheel package from Intel PyPI Cloud:
 
 ```
    python -m pip install --i https://software.repos.intel.com/python/pypi -extra-index-url https://pypi.org/simple mkl_umath numpy==<numpy_version>

--- a/mkl_umath/tests/test_basic.py
+++ b/mkl_umath/tests/test_basic.py
@@ -26,7 +26,6 @@
 import pytest
 import numpy as np
 import mkl_umath._ufuncs as mu
-import numpy.core.umath as nu
 
 np.random.seed(42)
 
@@ -56,10 +55,10 @@ generated_cases = {}
 for umath in umaths:
     mkl_umath = getattr(mu, umath)
     types = mkl_umath.types
-    for type in types:
-        args_str = type[:type.find('->')]
+    for type_ in types:
+        args_str = type_[:type_.find('->')]
         args = get_args(args_str)
-        generated_cases[(umath, type)] = args
+        generated_cases[(umath, type_)] = args
 
 additional_cases = {
     ('arccosh', 'f->f'): (np.single(np.random.random_sample() + 1),),
@@ -68,23 +67,20 @@ additional_cases = {
 
 test_cases = {**generated_cases, **additional_cases}
 
-@pytest.mark.parametrize("case", list(test_cases.keys()))
+def get_id(val):
+    return val.__str__()
+
+@pytest.mark.parametrize("case", test_cases, ids=get_id)
 def test_umath(case):
-    umath, type = case
+    umath, type_str = case
     args = test_cases[case]
     mkl_umath = getattr(mu, umath)
-    np_umath = getattr(nu, umath)
-    print('*'*80)
-    print(f"Testing {umath} with type {type}")
-    print("args:", args)
+    np_umath = getattr(np, umath)
     
     mkl_res = mkl_umath(*args)
     np_res = np_umath(*args)
-    
-    print("mkl res:", mkl_res)
-    print("npy res:", np_res)
-    
-    assert np.allclose(mkl_res, np_res), f"Results for {umath} do not match"
+       
+    assert np.allclose(mkl_res, np_res), f"Results for '{umath}': mkl_res: {mkl_res}, np_res: {np_res}"
 
 def test_cases_count():
     print("Test cases count:", len(test_cases))

--- a/mkl_umath/tests/test_basic.py
+++ b/mkl_umath/tests/test_basic.py
@@ -72,7 +72,7 @@ def get_id(val):
 
 @pytest.mark.parametrize("case", test_cases, ids=get_id)
 def test_umath(case):
-    umath, type_str = case
+    umath, _ = case
     args = test_cases[case]
     mkl_umath = getattr(mu, umath)
     np_umath = getattr(np, umath)


### PR DESCRIPTION
This PR updates the conda package workflow to run all `mkl_umath` tests and run on all supported Python versions