### PR TITLE
pin `setuptools >=77` in `meta.yaml` file of conda-recipe

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -20,7 +20,7 @@ requirements:
       - {{ compiler('dpcpp') }} >=2024.2  # [not osx]
       - sysroot_linux-64 >=2.28  # [linux]
     host:
-      - setuptools
+      - setuptools >=77
       - cmake
       - ninja
       - git

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
       - {{ compiler('dpcpp') }} >=2024.2  # [not osx]
       - sysroot_linux-64 >=2.28  # [linux]
     host:
-      - setuptools
+      - setuptools >=77
       - cmake
       - ninja
       - git


### PR DESCRIPTION
In https://github.com/IntelPython/mkl_umath/pull/63, setuptools was pinned to be >=77 in `pyproject.toml` which is needed for changes made there.

conda-recipe should have the same condition.