### PR TITLE
update tests

### DIFF
--- a/mkl_umath/tests/test_basic.py
+++ b/mkl_umath/tests/test_basic.py
@@ -44,7 +44,7 @@ def get_args(args_str):
         elif s == 'i':
             args.append(np.int_(np.random.randint(low=1, high=10)))
         elif s == 'l':
-            args.append(np.int64(np.random.randint(low=1, high=10)))
+            args.append(np.dtype('long').type(np.random.randint(low=1, high=10)))
         elif s == 'q':
             args.append(np.int64(np.random.randint(low=1, high=10)))
         else:


### PR DESCRIPTION
revert a change that was made https://github.com/IntelPython/mkl_umath/pull/73

On windows with numpy-2.x.x, we have 
```
>>> numpy.ldexp.types
['ei->e', 'fi->f', 'eq->e', 'fq->f', 'di->d', 'dq->d', 'gi->g', 'gq->g']
```
where `numpy.dtype("q") = dtype('int64')` so in https://github.com/IntelPython/mkl_umath/pull/73 an "if condition" for `s = 'q'` was added to `get_args` function in `test_basic.py`. The existing "if condition" for `s = 'l'` should not change since with numpy-1.26.x on Windows we have
```
>>> numpy.ldexp.types
['ei->e', 'fi->f', 'el->e', 'fl->f', 'di->d', 'dl->d', 'gi->g', 'gl->g']
```
where `numpy.dtype("l") = dtype('int32')`.

While on Linux for both numpy-1.26.x and numpy-2.x.x 
```
>>> numpy.ldexp.types
['ei->e', 'fi->f', 'el->e', 'fl->f', 'di->d', 'dl->d', 'gi->g', 'gl->g']
```
where `numpy.dtype("l") = dtype('int64')`.