### PR TITLE
install packages from intel channel for build using pip

### DIFF
--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -42,7 +42,8 @@ jobs:
 
       - name: Install Compiler and MKL
         run: |
-          conda install mkl-devel tbb-devel dpcpp_linux-64
+          CHANNELS="-c https://software.repos.intel.com/python/conda -c conda-forge --override-channels"        
+          conda install $CHANNELS mkl-devel tbb-devel dpcpp_linux-64
           python -c "import sys; print(sys.executable)"
           which python
 
@@ -52,7 +53,7 @@ jobs:
           pip install --no-cache-dir numpy ${{ matrix.use_pre }}
           echo "CONDA_PREFFIX is '${CONDA_PREFIX}'"
           export MKLROOT=${CONDA_PREFIX}
-          pip install . --no-build-isolation --no-deps --verbose
+          CC=icx pip install . --no-build-isolation --no-deps --verbose
           pip install --no-cache-dir pytest
           pip list
           # mkl_umath cannot be installed in editable mode, we need 

--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -35,15 +35,14 @@ jobs:
         with:
           use-mamba: true
           miniforge-version: latest
-          channels: conda-forge
+          channels: https://software.repos.intel.com/python/conda, conda-forge
           conda-remove-defaults: true
           activate-environment: test
           python-version: ${{ matrix.python }}
 
       - name: Install Compiler and MKL
         run: |
-          CHANNELS="-c https://software.repos.intel.com/python/conda -c conda-forge --override-channels"        
-          conda install $CHANNELS mkl-devel tbb-devel dpcpp_linux-64
+          conda install mkl-devel tbb-devel dpcpp_linux-64
           python -c "import sys; print(sys.executable)"
           which python
 


### PR DESCRIPTION
When `tbb-devel` is installed from conda-forge channel, `$CONDA_PREFIX/lib/cmake/tbb/TBBConfig.cmake` does not exist and it causes issue because when `TBBConfig.cmake` is not present, `find_package(MKL REQUIRED)` sets `MKL_FOUND=FALSE` with this reason: TBB not found for the specified MKL_THREADING: tbb_thread.
Installing `tbb-devel` from intel channel includes `$CONDA_PREFIX/lib/cmake/tbb/TBBConfig.cmake`.

`CC=icx` is also added to make sure The C compiler identification is IntelLLVM 2025.2.0 and not GNU cc.
