### PR TITLE
add new complex vm functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,6 @@ set_target_properties(${_trgt} PROPERTIES
     C_STANDARD 99
 )
 target_include_directories(${_trgt} PUBLIC mkl_umath/src/ ${Python_NumPy_INCLUDE_DIRS} ${Python_INCLUDE_DIRS})
-set(NPYMATH_PATH "${Python_NumPy_INCLUDE_DIRS}/../lib")
-target_link_libraries(${_trgt} PRIVATE ${NPYMATH_PATH}/libnpymath.a)
 target_link_libraries(${_trgt} PUBLIC MKL::MKL ${Python_LIBRARIES})
 target_link_options(${_trgt} PUBLIC ${_linker_options})
 target_compile_options(${_trgt} PUBLIC -fveclib=SVML)

--- a/mkl_umath/src/mkl_umath_loops.c.src
+++ b/mkl_umath/src/mkl_umath_loops.c.src
@@ -2695,7 +2695,7 @@ mkl_umath_@TYPE@_absolute(char **args, const npy_intp *dimensions, const npy_int
         UNARY_LOOP {
             const @ftype@ in1r = ((@ftype@ *)ip1)[0];
             const @ftype@ in1i = ((@ftype@ *)ip1)[1];
-            *((@ftype@ *)op1) = npy_hypot@c@(in1r, in1i);
+            *((@ftype@ *)op1) = hypot@c@(in1r, in1i);
         }
     }
     if(ignore_fpstatus) {


### PR DESCRIPTION
Added mkl implementation for complex data-types of `absolute` and `conjugate`.

Timing measurement using:
```python
import numpy, mkl_umath
size = 10**8
a = numpy.random.rand(size) + 1j*numpy.random.rand(size)
```

For absolute function:
```python
# numpy-2.3.1
%timeit numpy.absolute(a)
# 292 ms ± 319 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)

# This branch
%timeit mkl_umath.absolute(a)
# 46.4 ms ± 874 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Main branch
%timeit mkl_umath.absolute(a)
# 1.63 s ± 1.82 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
And for conjugate function:
```python
# numpy-2.3.1
%timeit numpy.conjugate(a)
# 439 ms ± 303 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)

# This branch
%timeit mkl_umath.conjugate(a)
# 42.9 ms ± 2.16 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# Main branch
%timeit mkl_umath.conjugate(a)
# 441 ms ± 372 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```