### PR TITLE
remove unused functions

### DIFF
--- a/mkl_umath/src/mkl_umath_loops.c.src
+++ b/mkl_umath/src/mkl_umath_loops.c.src
@@ -259,39 +259,6 @@ mkl_umath_@TYPE@_sqrt(char **args, const npy_intp *dimensions, const npy_intp *s
  * Float types
  *  #type = npy_float, npy_double#
  *  #TYPE = FLOAT, DOUBLE#
- *  #c = s, d#
- *  #scalarf = (1.0f)/sqrtf, (1.0)/sqrt#
- */
-
-void
-mkl_umath_@TYPE@_invsqrt(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func))
-{
-    const int contig = IS_UNARY_CONT(@type@, @type@);
-    const int disjoint_or_same = DISJOINT_OR_SAME(args[0], args[1], dimensions[0], sizeof(@type@));
-    const int can_vectorize = contig && disjoint_or_same;
-
-    if(can_vectorize && dimensions[0] > VML_TRANSCEDENTAL_THRESHOLD)
-    {
-        CHUNKED_VML_CALL2(v@c@InvSqrt, dimensions[0], @type@, args[0], args[1]);
-        /* v@c@InvSqrt(dimensions[0], (@type@*) args[0], (@type@*) args[1]); */
-    } else {
-        UNARY_LOOP_DISPATCH(
-            @type@, @type@
-            ,
-            can_vectorize
-            ,
-            const @type@ in1 = *(@type@ *)ip1;
-            *(@type@ *)op1 = @scalarf@(in1);
-        )
-    }
-}
-
-/**end repeat**/
-
-/**begin repeat
- * Float types
- *  #type = npy_float, npy_double#
- *  #TYPE = FLOAT, DOUBLE#
  *  #A = F, #
  *  #c = s, d#
  *  #scalarf = expf, exp#
@@ -386,39 +353,6 @@ mkl_umath_@TYPE@_expm1(char **args, const npy_intp *dimensions, const npy_intp *
     if(can_vectorize && dimensions[0] > VML_TRANSCEDENTAL_THRESHOLD) {
         CHUNKED_VML_CALL2(v@c@Expm1, dimensions[0], @type@, args[0], args[1]);
         /* v@c@Expm1(dimensions[0], (@type@*) args[0], (@type@*) args[1]); */
-    } else {
-        UNARY_LOOP_DISPATCH(
-            @type@, @type@
-            ,
-            can_vectorize
-            ,
-            const @type@ in1 = *(@type@ *)ip1;
-            *(@type@ *)op1 = @scalarf@(in1);
-        )
-    }
-}
-
-/**end repeat**/
-
-/**begin repeat
- * Float types
- *  #type = npy_float, npy_double#
- *  #TYPE = FLOAT, DOUBLE#
- *  #c = s, d#
- *  #scalarf = erff, erf#
- */
-
-void
-mkl_umath_@TYPE@_erf(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func))
-{
-    const int contig = IS_UNARY_CONT(@type@, @type@);
-    const int disjoint_or_same = DISJOINT_OR_SAME(args[0], args[1], dimensions[0], sizeof(@type@));
-    const int can_vectorize = contig && disjoint_or_same;
-
-    if( can_vectorize && dimensions[0] > VML_TRANSCEDENTAL_THRESHOLD)
-    {
-        CHUNKED_VML_CALL2(v@c@Erf, dimensions[0], @type@, args[0], args[1]);
-        /* v@c@Erf(dimensions[0], (@type@*) args[0], (@type@*) args[1]); */
     } else {
         UNARY_LOOP_DISPATCH(
             @type@, @type@
@@ -2190,14 +2124,6 @@ mkl_umath_@TYPE@_reciprocal(char **args, const npy_intp *dimensions, const npy_i
 }
 
 void
-mkl_umath_@TYPE@__ones_like(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        *((@type@ *)op1) = 1;
-    }
-}
-
-void
 mkl_umath_@TYPE@_conjugate(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func))
 {
     UNARY_LOOP {
@@ -2350,8 +2276,6 @@ mkl_umath_@TYPE@_ldexp_long(char **args, const npy_intp *dimensions, const npy_i
     }
 }
 #endif
-
-#define mkl_umath_@TYPE@_true_divide mkl_umath_@TYPE@_divide
 
 /**end repeat**/
 
@@ -2652,15 +2576,6 @@ mkl_umath_@TYPE@_reciprocal(char **args, const npy_intp *dimensions, const npy_i
 }
 
 void
-mkl_umath_@TYPE@__ones_like(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        ((@ftype@ *)op1)[0] = 1;
-        ((@ftype@ *)op1)[1] = 0;
-    }
-}
-
-void
 mkl_umath_@TYPE@_conjugate(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func)) {
     const int contig = IS_UNARY_CONT(@type@, @type@);
     const int disjoint_or_same = DISJOINT_OR_SAME(args[0], args[1], dimensions[0], sizeof(@type@));
@@ -2700,16 +2615,6 @@ mkl_umath_@TYPE@_absolute(char **args, const npy_intp *dimensions, const npy_int
     }
     if(ignore_fpstatus) {
         feclearexcept(FE_INVALID);
-    }
-}
-
-void
-mkl_umath_@TYPE@__arg(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func))
-{
-    UNARY_LOOP {
-        const @ftype@ in1r = ((@ftype@ *)ip1)[0];
-        const @ftype@ in1i = ((@ftype@ *)ip1)[1];
-        *((@ftype@ *)op1) = atan2@c@(in1i, in1r);
     }
 }
 
@@ -2811,8 +2716,6 @@ mkl_umath_@TYPE@_@kind@(char **args, const npy_intp *dimensions, const npy_intp 
     feclearexcept(FE_ALL_EXCEPT); /* clear floatstatus */
 }
 /**end repeat1**/
-
-#define mkl_umath_@TYPE@_true_divide mkl_umath_@TYPE@_divide
 
 /**end repeat**/
 

--- a/mkl_umath/src/mkl_umath_loops.h.src
+++ b/mkl_umath/src/mkl_umath_loops.h.src
@@ -59,10 +59,6 @@ mkl_umath_@TYPE@_sqrt(char **args, const npy_intp *dimensions, const npy_intp *s
 
 MKL_UMATH_API
 void
-mkl_umath_@TYPE@_invsqrt(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
-
-MKL_UMATH_API
-void
 mkl_umath_@TYPE@_exp(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 
 MKL_UMATH_API
@@ -72,10 +68,6 @@ mkl_umath_@TYPE@_exp2(char **args, const npy_intp *dimensions, const npy_intp *s
 MKL_UMATH_API
 void
 mkl_umath_@TYPE@_expm1(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
-
-MKL_UMATH_API
-void
-mkl_umath_@TYPE@_erf(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 
 MKL_UMATH_API
 void
@@ -223,10 +215,6 @@ mkl_umath_@TYPE@_@kind@(char **args, const npy_intp *dimensions, const npy_intp 
 
 MKL_UMATH_API
 void
-mkl_umath_@TYPE@_floor_divide(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
-
-MKL_UMATH_API
-void
 mkl_umath_@TYPE@_remainder(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 
 MKL_UMATH_API
@@ -240,10 +228,6 @@ mkl_umath_@TYPE@_square(char **args, const npy_intp *dimensions, const npy_intp 
 MKL_UMATH_API
 void
 mkl_umath_@TYPE@_reciprocal(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data));
-
-MKL_UMATH_API
-void
-mkl_umath_@TYPE@__ones_like(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data));
 
 MKL_UMATH_API
 void
@@ -287,8 +271,6 @@ void
 mkl_umath_@TYPE@_ldexp_long(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 #endif
 
-#define mkl_umath_@TYPE@_true_divide mkl_umath_@TYPE@_divide
-
 /**end repeat**/
 
 /*
@@ -326,10 +308,6 @@ MKL_UMATH_API
 void
 mkl_umath_@TYPE@_divide(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 
-MKL_UMATH_API
-void
-mkl_umath_@TYPE@_floor_divide(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
-
 
 /**begin repeat1
  * arithmetic
@@ -352,19 +330,11 @@ mkl_umath_@TYPE@_reciprocal(char **args, const npy_intp *dimensions, const npy_i
 
 MKL_UMATH_API
 void
-mkl_umath_@TYPE@__ones_like(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data));
-
-MKL_UMATH_API
-void
 mkl_umath_@TYPE@_conjugate(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data));
 
 MKL_UMATH_API
 void
 mkl_umath_@TYPE@_absolute(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data));
-
-MKL_UMATH_API
-void
-mkl_umath_@TYPE@__arg(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data));
 
 MKL_UMATH_API
 void
@@ -378,8 +348,6 @@ MKL_UMATH_API
 void
 mkl_umath_@TYPE@_@kind@(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 /**end repeat1**/
-
-#define mkl_umath_@TYPE@_true_divide mkl_umath_@TYPE@_divide
 
 /**end repeat**/
 


### PR DESCRIPTION
The following functions are removed from backend since they are not exposed and are not part of `numpy.ufuncs`: `invsqrt`, `erf`, `ones_like`, `arg`.

`floor_divide` is only defined in the header file without any implementation, so it is removed from header file.

`true_divide` in [numpy is internally an alias](https://github.com/numpy/numpy/blob/main/numpy/_core/code_generators/generate_umath.py#L400) of `divide`. So, when numpy is patched with `mkl_umath` (i.e. `mkl_umath.use_in_numpy()`) and `numpy.true_divide` is called, oneMKL implementation of divide will be called.