### PR TITLE
update recipe to use `numpy-base`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     run:
       - python
       - {{ pin_compatible('intel-cmplr-lib-rt') }}
-      - {{ pin_compatible('numpy') }}
+      - {{ pin_compatible('numpy-base') }}
 
 test:
     requires:


### PR DESCRIPTION
This will help to have the following dependency `mkl_* -> numpy-base` and then `numpy -> mkl_*, numpy-base`