### PR TITLE
Align wheels build logic with internal CI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -55,3 +55,12 @@ about:
     license: BSD-3
     license_file: LICENSE.txt
     summary: Universal functions for real and complex floating point arrays powered by Intel(R) Math Kernel Library Vector (Intel(R) MKL) and Intel(R) Short Vector Math Library (Intel(R) SVML)
+    description: |
+        <strong>LEGAL NOTICE: Use of this software package is subject to the
+        software license agreement (as set forth above, in the license section of
+        the installed Conda package and/or the README file) and all notices,
+        disclaimers or license terms for third party or open source software
+        included in or with the software.</strong>
+        <br/><br/>
+        EULA: <a href="https://opensource.org/licenses/BSD-3-Clause" target="_blank">BSD-3-Clause</a>
+        <br/><br/>

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
     number: {{ buildnumber }}
+    script_env:
+      - WHEELS_OUTPUT_FOLDER
     ignore_run_exports:
       - blas
 
@@ -30,6 +32,7 @@ requirements:
       - mkl-devel
       - tbb-devel
       - numpy-base
+      - wheel  >=0.41.3
     run:
       - python
       - {{ pin_compatible('intel-cmplr-lib-rt') }}


### PR DESCRIPTION
This PR adds the use of WHEELS_OUTPUT_FOLDER variable, which will allow us to build wheels in internal CI directly from this external recipe