### PR TITLE
[MAINT] Bump version to 0.4.0dev4

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.0dev3" %}
+{% set version = "0.4.0dev4" %}
 {% set buildnumber = 0 %}
 
 package:

--- a/mkl_umath/_version.py
+++ b/mkl_umath/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0dev3"
+__version__ = "0.4.0dev4"


### PR DESCRIPTION
This PR bumps `mkl_umath` version to 0.4.0dev4