### PR TITLE
Replace `mkl-service` dependency with `mkl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Import ufuncs explicitly in `__init__.py` and add `__all__` to module [gh-177](https://github.com/IntelPython/mkl_umath/pull/177)
 * Made conda recipe dependency on numpy configurable through `USE_NUMPY_BASE` environment variable [gh-181](https://github.com/IntelPython/mkl_umath/pull/181)
+* Removed `mkl-service` as a dependency in favor of `mkl`, as `mkl-service` is not used in `mkl_umath` directly [gh-188](https://github.com/IntelPython/mkl_umath/pull/188)
 
 ### Fixed
 * Build with ICX compiler from 2026.0 release [gh-155](https://github.com/IntelPython/mkl_umath/pull/155)

--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -31,6 +31,9 @@ requirements:
       - numpy
     run:
       - python
+      - python-gil     # [py>=314]
+      - {{ pin_compatible('mkl') }}
+      - {{ pin_compatible('numpy') }}
       - {{ pin_compatible('intel-cmplr-lib-rt') }}
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     run:
       - python
       - python-gil     # [py>=314]
-      - mkl-service
+      - {{ pin_compatible('mkl') }}
       - {{ pin_compatible('intel-cmplr-lib-rt') }}
       {% if use_numpy_base %}
       - numpy-base

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix"
 ]
-dependencies = ["numpy >=1.26.4", "mkl-service"]
+dependencies = ["numpy >=1.26.4", "mkl"]
 description = "Intel (R) MKL-based universal functions for NumPy arrays"
 dynamic = ["version"]
 keywords = ["mkl_umath"]


### PR DESCRIPTION
`mkl-service` was used to get `mkl` dependency in `mkl_umath`, but `mkl-service` functionality is never used in the package

For the sake of preventing unnecessary dependencies, `mkl-service` is dropped as a dependency in favor of `mkl`. Users can separately install `mkl-service` if they require runtime control of `mkl`.