### PR TITLE
Backport 0.4.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [1.4.1] - 2026-05-11
+## [0.4.1] - 2026-05-11
 
 ### Fixed
 * Removed `mkl` as runtime dependency to avoid possible `pip check` failures [gh-202](https://github.com/IntelPython/mkl_umath/pull/202)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [1.4.1] - 2026-05-11
+
+### Fixed
+* Removed `mkl` as runtime dependency to avoid possible `pip check` failures [gh-202](https://github.com/IntelPython/mkl_umath/pull/202)
+
 ## [0.4.0] - 2026-04-16
+
 ### Added
 * Added `patch_numpy_umath` and `restore_numpy_umath` functions for patching NumPy, and improved the patching implementation [gh-170](https://github.com/IntelPython/mkl_umath/pull/170)
 
@@ -63,7 +69,6 @@ This release updates `mkl_umath` to be aligned with both numpy-1.26.x and numpy-
 
 ### Fixed
 * Fixed a bug for `mkl_umath.is_patched` function [gh-66](https://github.com/IntelPython/mkl_umath/pull/66)
-
 
 ## [0.1.5] - 2025-04-09
 


### PR DESCRIPTION
This PR backports the changelog for 0.4.1 added to `maintenance/0.4.x` to master branch