### PR TITLE
Fix a typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.1] - 2026-05-11
+## [0.4.1] - 2026-05-11
 
 ### Fixed
 * Removed `mkl` as runtime dependency to avoid possible `pip check` failures [gh-202](https://github.com/IntelPython/mkl_umath/pull/202)


### PR DESCRIPTION
This PR fixes typo in the changelog with version of `0.4.1` release