### PR TITLE
Use correct `mkl_umath` version in public CI testing

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -102,7 +102,8 @@ jobs:
       - name: Collect dependencies
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
-          conda create -n test_mkl_umath "$PACKAGE_NAME" "python=${{ matrix.python }}" "${CHANNELS[@]}" --only-deps --dry-run > lockfile
+          PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
+          conda create -n test_mkl_umath "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" "${CHANNELS[@]}" --only-deps --dry-run > lockfile
       - name: Display lockfile
         run: cat lockfile
 
@@ -125,7 +126,8 @@ jobs:
       - name: Install mkl_umath
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
-          conda create -n test_mkl_umath "python=${{ matrix.python }}" "$PACKAGE_NAME" pytest "${CHANNELS[@]}"
+          PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
+          conda create -n test_mkl_umath "python=${{ matrix.python }}" "$PACKAGE_NAME=${PACKAGE_VERSION}" pytest "${CHANNELS[@]}"
           # Test installed packages
           conda list -n test_mkl_umath
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -10,8 +10,11 @@ permissions: read-all
 
 env:
   PACKAGE_NAME: mkl_umath
+  MODULE_NAME: mkl_umath
+  TEST_ENV_NAME: test_mkl_umath
   VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); d = j['mkl_umath'][0];"
   VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
+  CONDA_BUILD_VERSION: 26.3.0
 
 jobs:
   build_linux:
@@ -47,8 +50,20 @@ jobs:
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
 
+      - name: Update conda
+        run: |
+          conda update -n base --all
+
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install -n base conda-build=${{ env.CONDA_BUILD_VERSION }} -c conda-forge --override-channels
+
+      - name: Show Conda info
+        run: |
+          conda info --all
+
+      - name: List base environment packages
+        run: |
+          conda list -n base
 
       - name: Build conda package
         run: |
@@ -87,10 +102,20 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+      - name: Update conda
+        run: |
+          conda update -n base --all
+      - name: Install conda-index
+        run: |
+          conda install -n base conda-index -c conda-forge --override-channels
+      - name: Show Conda info
+        run: |
+          conda info --all
+      - name: List base environment packages
+        run: |
+          conda list -n base
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
-      - name: Install conda-build
-        run: conda install conda-build
       - name: Create conda channel
         run: |
           mkdir -p "$GITHUB_WORKSPACE/channel/linux-64"
@@ -103,7 +128,7 @@ jobs:
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
           PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
-          conda create -n test_mkl_umath "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" "${CHANNELS[@]}" --only-deps --dry-run > lockfile
+          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" "${CHANNELS[@]}" --only-deps --dry-run > lockfile
       - name: Display lockfile
         run: cat lockfile
 
@@ -127,21 +152,21 @@ jobs:
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
           PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
-          conda create -n test_mkl_umath "python=${{ matrix.python }}" "$PACKAGE_NAME=${PACKAGE_VERSION}" pytest "${CHANNELS[@]}"
+          conda create -n "${{ env.TEST_ENV_NAME }}" "python=${{ matrix.python }}" "$PACKAGE_NAME=${PACKAGE_VERSION}" pytest "${CHANNELS[@]}"
           # Test installed packages
-          conda list -n test_mkl_umath
+          conda list -n "${{ env.TEST_ENV_NAME }}"
 
       - name: Smoke test
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
-          conda activate test_mkl_umath
+          conda activate "${{ env.TEST_ENV_NAME }}"
           python -c "import mkl_umath, numpy as np; mkl_umath.patch_numpy_umath(); np.sin(np.linspace(0, 1, num=10**6));"
 
       - name: Run tests
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
-          conda activate test_mkl_umath
-          pytest -v --pyargs ${{ env.PACKAGE_NAME }}
+          conda activate "${{ env.TEST_ENV_NAME }}"
+          pytest -v --pyargs ${{ env.MODULE_NAME }}
 
   build_windows:
     runs-on: windows-latest
@@ -162,12 +187,12 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
-          miniforge-variant: Miniforge3
+          auto-update-conda: true
           miniforge-version: latest
           activate-environment: build
           channels: conda-forge
-          conda-remove-defaults: "true"
           python-version: ${{ matrix.python }}
+          conda-build-version: ${{ env.CONDA_BUILD_VERSION }}
 
       - name: Cache conda packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -227,9 +252,9 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
-          miniforge-variant: Miniforge3
+          auto-update-conda: true
           miniforge-version: latest
-          activate-environment: mkl_umath_test
+          activate-environment: ${{ env.TEST_ENV_NAME }}
           channels: conda-forge
           conda-remove-defaults: "true"
           python-version: ${{ matrix.python }}
@@ -237,6 +262,14 @@ jobs:
       - name: Install conda-index
         run: |
           conda install -n base conda-index
+
+      - name: Show Conda info
+        run: |
+          conda info --all
+
+      - name: List base environment packages
+        run: |
+          conda list -n base
 
       - name: Create conda channel with the artifact bit
         shell: cmd /C CALL {0}
@@ -281,7 +314,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          conda install -n mkl_umath_test ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
 
       - name: Display lockfile content
         shell: pwsh
@@ -315,7 +348,7 @@ jobs:
           SET "TEST_DEPENDENCIES=pytest pytest-cov"
           SET "WORKAROUND_DEPENDENCIES=intel-openmp"
           SET "DEPENDENCIES=%TEST_DEPENDENCIES% %WORKAROUND_DEPENDENCIES%"
-          conda install -n mkl_umath_test ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment
         shell: cmd /C CALL {0}
@@ -323,17 +356,17 @@ jobs:
           conda activate
           echo "Value of CONDA environment variable was: " %CONDA%
           echo "Value of CONDA_PREFIX environment variable was: " %CONDA_PREFIX%
-          conda info && conda list -n mkl_umath_test
+          conda info && conda list -n ${{ env.TEST_ENV_NAME }}
 
       - name: Smoke test
         shell: cmd /C CALL {0}
         run: |
           @ECHO ON
-          conda activate mkl_umath_test
+          conda activate ${{ env.TEST_ENV_NAME }}
           python -c "import mkl_umath, numpy as np; mkl_umath.patch_numpy_umath(); np.sin(np.linspace(0, 1, num=10**6));"
 
       - name: Run tests
         shell: cmd /C CALL {0}
         run: |
-          conda activate mkl_umath_test
-          python -m pytest -v -s --pyargs ${{ env.PACKAGE_NAME }}
+          conda activate ${{ env.TEST_ENV_NAME }}
+          python -m pytest -v -s --pyargs ${{ env.MODULE_NAME }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -134,7 +134,10 @@ jobs:
           conda index "$GITHUB_WORKSPACE/channel"
           # Test channel
           conda search "$PACKAGE_NAME" -c "$GITHUB_WORKSPACE/channel" --override-channels
-
+      - name: Test conda channel
+        run: |
+          conda search "$PACKAGE_NAME" -c "$GITHUB_WORKSPACE"/channel --override-channels --info --json > "$GITHUB_WORKSPACE"/ver.json
+          cat "$GITHUB_WORKSPACE"/ver.json
       - name: Collect dependencies
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -21,7 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python: "3.10"
+            numpy: "2.2"
+          - python: "3.11"
+            numpy: "2.3"
+          - python: "3.12"
+            numpy: "2.3"
+          - python: "3.13"
+            numpy: "2.3"
+          - python: "3.14"
+            numpy: "2.3"
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
@@ -68,7 +78,7 @@ jobs:
       - name: Build conda package
         run: |
           CHANNELS=(-c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
-          VERSIONS=(--python "${{ matrix.python }}")
+          VERSIONS=(--python "${{ matrix.python }}" --numpy "${{ matrix.numpy }}")
           TEST=(--no-test)
           echo "CONDA_BLD=${CONDA}/conda-bld/linux-64" >> "$GITHUB_ENV"
 
@@ -91,6 +101,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        numpy: ['numpy">=2"']
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -128,7 +139,7 @@ jobs:
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
           PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
-          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" "${CHANNELS[@]}" --only-deps --dry-run > lockfile
+          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" ${{ matrix.numpy }} "${CHANNELS[@]}" --only-deps --dry-run > lockfile
       - name: Display lockfile
         run: cat lockfile
 
@@ -152,7 +163,7 @@ jobs:
         run: |
           CHANNELS=(-c "$GITHUB_WORKSPACE/channel" -c "https://software.repos.intel.com/python/conda" -c "conda-forge" --override-channels)
           PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
-          conda create -n "${{ env.TEST_ENV_NAME }}" "python=${{ matrix.python }}" "$PACKAGE_NAME=${PACKAGE_VERSION}" pytest "${CHANNELS[@]}"
+          conda create -n "${{ env.TEST_ENV_NAME }}" "python=${{ matrix.python }}" ${{ matrix.numpy }} "$PACKAGE_NAME=${PACKAGE_VERSION}" pytest "${CHANNELS[@]}"
           # Test installed packages
           conda list -n "${{ env.TEST_ENV_NAME }}"
 
@@ -173,7 +184,17 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python: "3.10"
+            numpy: "2.2"
+          - python: "3.11"
+            numpy: "2.3"
+          - python: "3.12"
+            numpy: "2.3"
+          - python: "3.13"
+            numpy: "2.3"
+          - python: "3.14"
+            numpy: "2.3"
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
@@ -220,7 +241,7 @@ jobs:
       - name: Build conda package
         run: |
           conda activate
-          conda build --no-test --python ${{ matrix.python }} -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels conda-recipe
+          conda build --no-test --python ${{ matrix.python }} --numpy ${{ matrix.numpy }} -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -237,6 +258,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        numpy: ['numpy">=2"']
         experimental: [false]
         runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -314,7 +336,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} ${{ matrix.numpy }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
 
       - name: Display lockfile content
         shell: pwsh
@@ -348,7 +370,7 @@ jobs:
           SET "TEST_DEPENDENCIES=pytest pytest-cov"
           SET "WORKAROUND_DEPENDENCIES=intel-openmp"
           SET "DEPENDENCIES=%TEST_DEPENDENCIES% %WORKAROUND_DEPENDENCIES%"
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %DEPENDENCIES% python=${{ matrix.python }} ${{ matrix.numpy }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment
         shell: cmd /C CALL {0}


### PR DESCRIPTION
conda-package workflow was installing `mkl_umath` from Intel channel instead of the local artifact