### PR TITLE
Remove Windows numpy <2.4 pin from conda-forge recipe

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -30,9 +30,7 @@ requirements:
       - python
       - python-gil     # [py>=314]
       - mkl-devel
-      - numpy  # [not win]
-      - numpy <2.4  # [win]
-      # TODO: remove win numpy pin when numpy 2.5 is released, see https://github.com/numpy/numpy/issues/31337
+      - numpy
       - llvm-openmp
     run:
       - python


### PR DESCRIPTION
This PR removes the Windows-specific `numpy <2.4` host pin (and its accompanying TODO) from the conda-forge recipe, now that numpy 2.5 has been released.