### PR TITLE
Backport 0.4.3 changelog entry to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Removed `numpy-base` dependency and `USE_NUMPY_BASE` environment variable from conda recipe [gh-200](https://github.com/IntelPython/mkl_umath/pull/200)
-* Updated `mkl_umath` patching to work with changes to NumPy Cython API present in NumPy 2.5 [gh-226](https://github.com/IntelPython/mkl_umath/pull/226)
 
 ### Fixed
+
+## [0.4.3] - 2026-06-30
+
+### Changed
+* Updated `mkl_umath` patching to work with changes to NumPy Cython API present in NumPy 2.5 [gh-226](https://github.com/IntelPython/mkl_umath/pull/226)
 
 ## [0.4.2] - 2026-05-28
 


### PR DESCRIPTION
Backports the finalized `0.4.3` changelog section from `maintenance/0.4.x` to `main`.

- Adds the released `## [0.4.3] - 2026-06-30` section
- Moves the gh-226 entry out of the unreleased `[dev]` section into `[0.4.3]`, since it shipped in the 0.4.3 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)