### PR TITLE
Use valid SPDX license identifier in conda-recipe-cf

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -55,6 +55,6 @@ test:
 
 about:
     home: http://github.com/IntelPython/mkl_umath
-    license: BSD-3
+    license: BSD-3-Clause
     license_file: LICENSE.txt
     summary: Universal functions for real and complex floating point arrays powered by Intel(R) Math Kernel Library Vector (Intel(R) MKL) and Intel(R) Short Vector Math Library (Intel(R) SVML)


### PR DESCRIPTION
## Summary
- `conda-recipe-cf/meta.yaml` declared `license: BSD-3`, which is not a valid SPDX identifier.
- Corrected to `BSD-3-Clause`, matching the 3-clause BSD text in `LICENSE.txt` and the sibling `conda-recipe/meta.yaml` (which already uses `BSD-3-Clause`).

## Why
conda-forge recipes are expected to use valid SPDX license expressions in the `about.license` field. `BSD-3` is not recognized; `BSD-3-Clause` is the canonical identifier for the license this project ships.