### PR TITLE
Guard `main` instead of `master` in no-commit-to-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     - id: check-added-large-files
     - id: no-commit-to-branch
       name: "ensure no direct commit to master/maintenance branches"
-      args: [--branch, "master", --pattern, "maintenance/.*"]
+      args: [--branch, "main", --pattern, "maintenance/.*"]
     - id: check-case-conflict
     - id: check-illegal-windows-names
   # Contents


### PR DESCRIPTION
## Summary

The `no-commit-to-branch` pre-commit hook was configured to guard the `master` branch, but this repository's default branch is `main` — there is no `master` branch. This meant the hook was effectively guarding a nonexistent branch.

This updates the hook's `--branch` argument from `master` to `main` so direct commits to the default branch are actually blocked.

## Changes

- `.pre-commit-config.yaml`: `args: [--branch, "master", ...]` → `args: [--branch, "main", ...]`